### PR TITLE
move chosen design to index instead of copying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 2023
 
+## [1.0.40] - February 2
+### Updated
+- Move chosen design to index.astro instead of copying
+
 ## [1.0.39] - January 30
 ### Updated
 - Add typology layout with fonts

--- a/bin/init.js
+++ b/bin/init.js
@@ -139,8 +139,7 @@ var main = async () => {
     await fs.copyFile(py,py2);
     await fs.copyFile(js,js2);
   }
-  const chosenDesign = `${srcDir}/src/pages/${design}.astro`
-  await fs.copyFile(chosenDesign,`${projectDir}/src/pages/index.astro`);
+  await fs.rename(`${projectDir}/src/pages/${design}.astro`,`${projectDir}/src/pages/index.astro`);
   const pkgJson = await fs.readJSON(path.join(projectDir, "package.json"));
   pkgJson.name = appName;
   await fs.writeJSON(path.join(projectDir, "package.json"), pkgJson, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "venlo",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "venlo",
-      "version": "1.0.39",
+      "version": "1.0.40",
       "license": "ISC",
       "dependencies": {
         "chalk": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "venlo",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## [1.0.40] - February 2
### Updated
- Move chosen design to index.astro instead of copying

