### PR TITLE
fix: grep for rules correctly in makefile tldr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ NPM_TOKEN=$(shell awk -F'=' '{print $$2}' ~/.npmrc)
 tldr:
 	@echo Available commands
 	@echo ------------------
-	@for i in `grep -v "\t" Makefile | grep "a*:" | awk -F ":" '{print $$1}'`; do echo make $$i; done
+	@for i in `grep '^[[:alpha:]]*:' Makefile | awk -F ":" '{print $$1}'`; do echo make $$i; done
 generate:
 	./bin/init.js
 gh:

--- a/template/astro/Makefile
+++ b/template/astro/Makefile
@@ -1,7 +1,7 @@
 tldr:
 	@echo Available commands
 	@echo ------------------
-	@for i in `grep -v "\t" Makefile | grep "a*:" | tr -d \:`; do echo make $$i; done
+	@for i in `grep '^[[:alpha:]]*:' Makefile | tr -d \:`; do echo make $$i; done
 start:
 	npm run dev
 build:

--- a/template/next/Makefile
+++ b/template/next/Makefile
@@ -1,7 +1,7 @@
 tldr:
 	@echo Available commands
 	@echo ------------------
-	@for i in `grep -v "\t" Makefile | grep "a*:" | tr -d \:`; do echo make $$i; done
+	@for i in `grep '^[[:alpha:]]*:' Makefile | tr -d \:`; do echo make $$i; done
 start:
 	npm run dev
 vercel:


### PR DESCRIPTION
grep for lines starting with alphabetic chars and ending with colon instead of grepping for absence ot tab
